### PR TITLE
Add TAC Life Support .cfg, fixes issue #35

### DIFF
--- a/GameData/UmbraSpaceIndustries/SrvPack/PodCapsule/PodCapsule.cfg
+++ b/GameData/UmbraSpaceIndustries/SrvPack/PodCapsule/PodCapsule.cfg
@@ -94,6 +94,7 @@ PART
 	MODULE
 	{
 		name = ModuleStoredResource
+		tag = USI_LS
 		ResourceName = Supplies
 		Amount = 5
 	}

--- a/GameData/UmbraSpaceIndustries/SrvPack/TAC_LS.cfg
+++ b/GameData/UmbraSpaceIndustries/SrvPack/TAC_LS.cfg
@@ -1,0 +1,22 @@
+@PART[USI_PodCapsule]:NEEDS[TACLifeSupport]
+{
+	!MODULE[ModuleStoredResource,USI_LS] {}
+	MODULE
+	{
+		name = ModuleStoredResource
+		ResourceName = Food
+		Amount = 5.484375
+	}
+	MODULE
+	{
+		name = ModuleStoredResource
+		ResourceName = Water
+		Amount = 3.6249375
+	}
+	MODULE
+	{
+		name = ModuleStoredResource
+		ResourceName = Oxygen
+		Amount = 555.186170213
+	}
+}


### PR DESCRIPTION
15 days (should be, tested with TAC LS 0.11.1.20), should probably do same for USI LS resources (otherwise mod fails to add other stored resources (e.g. monopropellant) when inflating PodCapsule if user doesn't have USI LS)